### PR TITLE
Makes the plugin useful for Enterprise customers

### DIFF
--- a/mailer.http.class.php
+++ b/mailer.http.class.php
@@ -40,6 +40,10 @@ class SparkPostHTTPMailer extends \PHPMailer
     {
         $this->edebug('Preparing request data');
 
+        if (!empty($this->settings['api_endpoint'])) {
+            $this->endpoint = $this->settings['api_endpoint'];
+        }
+
         $data = array(
             'method' => 'POST',
             'timeout' => 15,
@@ -79,6 +83,11 @@ class SparkPostHTTPMailer extends \PHPMailer
         // add recipients
         $body['recipients'] = $this->get_recipients();
 
+        // set required return path for enterprise customers
+        if (strpos($this->endpoint, '.sparkpostelite.com') !== false || strpos($this->endpoint, '.msyscloud.com')) {
+            $body['return_path'] = $sender['email'];
+        }
+
         // enable engagement tracking
         $body['options'] = array(
             'open_tracking' => (bool) apply_filters('wpsp_open_tracking', $tracking_enabled),
@@ -86,10 +95,14 @@ class SparkPostHTTPMailer extends \PHPMailer
             'transactional' => (bool) apply_filters('wpsp_transactional', $this->settings['transactional'])
         );
 
+        if (!empty($this->settings['ip_pool'])) {
+            $body['options']['ip_pool'] = $this->settings['ip_pool'];
+        }
+
         $template_id = apply_filters('wpsp_template_id', $this->settings['template']);
 
         // pass through either stored template or inline content
-        if (!empty($template_id)) { 
+        if (!empty($template_id)) {
             // stored template
             $body['content']['template_id'] = $template_id;
 

--- a/mailer.smtp.class.php
+++ b/mailer.smtp.class.php
@@ -33,14 +33,18 @@ class SparkPostSMTPMailer
             )
         );
 
+        if (!empty($this->settings['ip_pool'])) {
+            $x_msys_api['options']['ip_pool'] = $this->settings['ip_pool'];
+        }
+
         $phpmailer->isSMTP();
         $phpmailer->SMTPSecure = 'tls';
         $phpmailer->Port = !empty($settings['port']) ? intval($settings['port']) : 587;
-        $phpmailer->Host = 'smtp.sparkpostmail.com';
+        $phpmailer->Host = !empty($settings['smtp_host']) ? $settings['smtp_host'] : 'smtp.sparkpostmail.com';
         $phpmailer->SMTPAuth = true;
         $phpmailer->Username = 'SMTP_Injection';
         $phpmailer->Password = apply_filters('wpsp_api_key', $settings['password']);
-        $phpmailer->XMailer = $xmailer; 
+        $phpmailer->XMailer = $xmailer;
 
         $json_x_msys_api = apply_filters('wpsp_smtp_msys_api', $x_msys_api);
         $phpmailer->addCustomHeader('X-MSYS-API', json_encode($json_x_msys_api));

--- a/sparkpost.class.php
+++ b/sparkpost.class.php
@@ -17,10 +17,14 @@ class SparkPost
         'password' => '',
         'from_name' => '',
         'from_email' => '',
+        'api_endpoint' => '',
+        'smtp_host' => '',
         'enable_sparkpost' => false,
         'enable_tracking' => true,
         'template' => '',
-        'transactional' => false
+        'campaign_id' => '',
+        'transactional' => false,
+        'ip_pool' => ''
     );
 
     var $settings;


### PR DESCRIPTION
- Added campaign_id and ip_pool general options
- Added api_endpoint and smtp_host overrides
- When an Enterprise domain is set the return_path is automatically set (only necessary for the API method as PHP mailer will set it automatically when using SMTP)