### PR TITLE
Attachments in templates

### DIFF
--- a/admin.widget.class.php
+++ b/admin.widget.class.php
@@ -234,7 +234,7 @@ class SparkPostAdmin
         printf(
             '<input type="text" id="password" name="sp_settings[password]" class="regular-text" value="%s" /><br/>
             <small><ul><li>For SMTP, set up an API key with the <strong>Send via SMTP</strong> permission</li>
-            <li>For HTTP API, set up an API Key with the <strong>Transmissions: Read/Write, Templates: Preview</strong> permissions</li><a href="https://support.sparkpost.com/customer/portal/articles/1933377-create-api-keys" target="_blank">Need help creating a SparkPost API key?</a></small>',
+            <li>For HTTP API, set up an API Key with the <strong>Transmissions: Read/Write, Templates: Read/Write</strong> permissions</li><a href="https://support.sparkpost.com/customer/portal/articles/1933377-create-api-keys" target="_blank">Need help creating a SparkPost API key?</a></small>',
             isset($api_key) ? $api_key : ''
         );
     }

--- a/admin.widget.class.php
+++ b/admin.widget.class.php
@@ -56,8 +56,8 @@ class SparkPostAdmin
         $result = wp_mail($recipient,
             'SparkPost email test',
             '<h3>Hurray!!</h3><p>You\'ve got mail! <br/><br> Regards,<br/><a href="https://www.sparkpost.com">SparkPost</a> WordPress plugin</p>',
-            $headers,
-            $attachments
+            $headers
+            , $attachments
         );
         remove_filter('wp_mail_content_type', array($this, 'set_html_content_type'));
         return $result;

--- a/admin.widget.class.php
+++ b/admin.widget.class.php
@@ -327,6 +327,6 @@ class SparkPostAdmin
 
     public function render_include_attachment_field()
     {
-        echo '<label><input type="checkbox" id="include_attachment" name="include_attachment" value="1" %s />Include Attachment</label>';
+        echo '<label><input type="checkbox" id="include_attachment" name="include_attachment" value="1" />Include Attachment</label>';
     }
 }

--- a/admin.widget.class.php
+++ b/admin.widget.class.php
@@ -53,10 +53,10 @@ class SparkPostAdmin
         add_filter('wp_mail_content_type', array($this, 'set_html_content_type'));
         $headers = array();
         $attachments= array(__DIR__ . '/sample.txt');
-        $result = wp_mail($recipient,
-            'SparkPost email test',
-            '<h3>Hurray!!</h3><p>You\'ve got mail! <br/><br> Regards,<br/><a href="https://www.sparkpost.com">SparkPost</a> WordPress plugin</p>',
-            $headers
+        $result = wp_mail($recipient
+            , 'SparkPost email test'
+            , '<h3>Hurray!!</h3><p>You\'ve got mail! <br/><br> Regards,<br/><a href="https://www.sparkpost.com">SparkPost</a> WordPress plugin</p>'
+            , $headers
             , $attachments
         );
         remove_filter('wp_mail_content_type', array($this, 'set_html_content_type'));
@@ -233,7 +233,8 @@ class SparkPostAdmin
 
         printf(
             '<input type="text" id="password" name="sp_settings[password]" class="regular-text" value="%s" /><br/>
-            <small><ul><li>For SMTP, set up an API key with the <strong>Send via SMTP</strong> permission</li> <li>For HTTP API, set up an API Key with the <strong>Transmissions: Read/Write</strong> permission</li><a href="https://support.sparkpost.com/customer/portal/articles/1933377-create-api-keys" target="_blank">Need help creating a SparkPost API key?</a></small>',
+            <small><ul><li>For SMTP, set up an API key with the <strong>Send via SMTP</strong> permission</li>
+            <li>For HTTP API, set up an API Key with the <strong>Transmissions: Read/Write, Templates: Preview</strong> permissions</li><a href="https://support.sparkpost.com/customer/portal/articles/1933377-create-api-keys" target="_blank">Need help creating a SparkPost API key?</a></small>',
             isset($api_key) ? $api_key : ''
         );
     }
@@ -247,7 +248,6 @@ class SparkPostAdmin
             <ul>
                 <li>- Please see <a href="https://support.sparkpost.com/customer/portal/articles/2409547-using-templates-with-the-sparkpost-wordpress-plugin" target="_blank">this article</a> for detailed information about using templates with this plugin.</li>
                 <li>- Templates can only be used with the HTTP API.</li>
-                <li>- <a href="https://github.com/SparkPost/wordpress-sparkpost/blob/master/docs/templates-attachments.md" target="_blank">Does not work with attachment.</a>
                 <li>- Leave this field blank to disable use of a template. You can still specify it by <a href="https://github.com/SparkPost/wordpress-sparkpost/blob/master/docs/hooks.md" target="_blank">using hooks</a>.</li>
             </ul>
         </small>
@@ -256,7 +256,7 @@ class SparkPostAdmin
 
     public function render_from_email_field()
     {
-        $hint = 'Important: Domain must match with one of your verified sending domains.';
+        $hint = '<strong>Important:</strong> Domain must match with one of your verified sending domains.';
         if(empty($this->settings['from_email'])){
             $hostname = parse_url(get_bloginfo('url'), PHP_URL_HOST);
             $hint .= sprintf(' When left blank, <strong>%s</strong> will be used as email domain', $hostname);

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -27,3 +27,4 @@ Hook names are prefixed with `wpsp_`.
 | wpsp_body_headers            | Filter   |   
 | wpsp_smtp_msys_api           | Filter   |
 | wpsp_transactional           | Filter   | Set whether an email is transactional or not.
+| wpsp_substitution_data       | Filter   | Modify substitution_data object

--- a/mailer.http.class.php
+++ b/mailer.http.class.php
@@ -19,6 +19,7 @@ class SparkPostHTTPMailer extends \PHPMailer
     function __construct($exceptions = false)
     {
         $this->settings = SparkPost::get_settings();
+        $this->template = new SparkPostTemplates($this);
 
         parent::__construct($exceptions);
         do_action('wpsp_init_mailer', $this);
@@ -121,7 +122,7 @@ class SparkPostHTTPMailer extends \PHPMailer
           // stored template
           $substitution_data = $this->get_template_substitutes($sender, $replyTo);
           if(sizeof($attachments) > 0){ //get template preview data and then send it as inline
-            $preview_contents = $this->get_template_preview($template_id, $substitution_data);
+            $preview_contents = $this->template->preview($template_id, $substitution_data);
             if($preview_contents === false) {
               return false;
             }

--- a/mailer.http.class.php
+++ b/mailer.http.class.php
@@ -300,7 +300,7 @@ class SparkPostHTTPMailer extends \PHPMailer
         return apply_filters('wpsp_recipients', $recipients);
     }
 
-    function get_request_headers($hide_api_key = false)
+    public function get_request_headers($hide_api_key = false)
     {
         $api_key = apply_filters('wpsp_api_key', $this->settings['password']);
         if ($hide_api_key) {

--- a/mailer.http.class.php
+++ b/mailer.http.class.php
@@ -59,6 +59,7 @@ class SparkPostHTTPMailer extends \PHPMailer
         $result = $this->request($this->endpoint, $data);
 
         $result = apply_filters('wpsp_handle_response', $result);
+        $this->check_permission_error($result, 'Transmissions: Read/Write');
         if(is_bool($result)) { // it means, response been already processed by the hooked filter. so just return the value.
           $this->debug('Skipping response processing');
           return $result;
@@ -456,9 +457,11 @@ class SparkPostHTTPMailer extends \PHPMailer
     }
 
     function check_permission_error($response, $permission) {
-      if($response['response']['code'] === 403) {
+      $response = (array) $response;
+      if(!empty($response['response']) && $response['response']['code'] === 403) {
         $this->debug("API Key might not have {$permission} permission. Actual Error: " . print_r($response['response'], true));
         $this->error("API Key might not have {$permission} permission");
+        return false;
       }
     }
 

--- a/mailer.http.class.php
+++ b/mailer.http.class.php
@@ -461,8 +461,9 @@ class SparkPostHTTPMailer extends \PHPMailer
       if(!empty($response['response']) && $response['response']['code'] === 403) {
         $this->debug("API Key might not have {$permission} permission. Actual Error: " . print_r($response['response'], true));
         $this->error("API Key might not have {$permission} permission");
-        return false;
+        return true;
       }
+      return false;
     }
 
     public function debug($msg) {

--- a/mailer.http.class.php
+++ b/mailer.http.class.php
@@ -88,11 +88,6 @@ class SparkPostHTTPMailer extends \PHPMailer
       return apply_filters('wpsp_substitution_data', $substitution_data);
     }
 
-    function get_template_preview($template_id, $substitution_data) {
-        $template = new SparkPostTemplates($this);
-        return $template->preview($template_id, $substitution_data);
-    }
-
     /**
      * Build the request body to be sent to the SparkPost API.
      */

--- a/templates.class.php
+++ b/templates.class.php
@@ -9,7 +9,6 @@ class SparkPostTemplates {
 
   public function __construct($mailer){
     $this->mailer = $mailer;
-    $this->settings = SparkPost::get_settings();
   }
 
 

--- a/templates.class.php
+++ b/templates.class.php
@@ -3,7 +3,6 @@ namespace WPSparkPost;
 // If ABSPATH is defined, we assume WP is calling us.
 // Otherwise, this could be an illicit direct request.
 if (!defined('ABSPATH')) exit();
-// require_once WPSP_PLUGIN_DIR '/sparkpost.class.php';
 
 class SparkPostTemplates {
   public $endpoint = 'https://api.sparkpost.com/api/v1/templates';
@@ -12,6 +11,7 @@ class SparkPostTemplates {
     $this->mailer = $mailer;
     $this->settings = SparkPost::get_settings();
   }
+
 
   public function preview($id, $substitution_data){
     $url = "{$this->endpoint}/{$id}/preview?draft=false";
@@ -28,20 +28,26 @@ class SparkPostTemplates {
       'body' => json_encode($body)
     );
 
+    $this->mailer->debug('Making template API request');
+    $this->mailer->debug(print_r($data, true));
+
     $response = $http->request($url, $data);
+    $this->mailer->debug('Template API request completed');
+    $this->mailer->check_permission_error($response, 'Templates: Read/Write');
+
     $body = json_decode($response['body']);
 
     if (property_exists($body, 'errors')) {
-      $this->mailer->edebug('Error in getting template data');
-      $this->mailer->setError($body->errors);
+      $this->mailer->debug('Error in getting template data');
+      $this->mailer->error($body->errors);
       return false;
     }
 
     if (property_exists($body, 'results')) {
       return $body->results;
     } else {
-      $this->mailer->edebug('API response is unknown');
-      $this->mailer->setError('Unknown response');
+      $this->mailer->debug('API response is unknown');
+      $this->mailer->error('Unknown response');
       return false;
     }
   }

--- a/templates.class.php
+++ b/templates.class.php
@@ -1,0 +1,60 @@
+<?php
+namespace WPSparkPost;
+// If ABSPATH is defined, we assume WP is calling us.
+// Otherwise, this could be an illicit direct request.
+if (!defined('ABSPATH')) exit();
+// require_once WPSP_PLUGIN_DIR '/sparkpost.class.php';
+
+class SparkPostTemplates {
+  public $endpoint = 'https://api.sparkpost.com/api/v1/templates';
+
+  public function __construct(){
+    $this->settings = SparkPost::get_settings();
+  }
+
+  protected function get_request_headers($hide_api_key = false)
+  {
+      $api_key = apply_filters('wpsp_api_key', $this->settings['password']);
+
+      return apply_filters('wpsp_request_headers', array(
+          'User-Agent' => 'wordpress-sparkpost/' . WPSP_PLUGIN_VERSION,
+          'Content-Type' => 'application/json',
+          'Authorization' => $api_key
+      ));
+  }
+
+  public function preview($id, $substitution_data){
+    $url = "{$this->endpoint}/{$id}/preview?draft=false";
+    $http = apply_filters('wpsp_get_http_lib', _wp_http_get_object());
+
+    $body = array(
+      'substitution_data' => $substitution_data
+    );
+
+    $data = array(
+        'method' => 'POST',
+        'timeout' => 15,
+        'headers' => $this->get_request_headers(),
+        'body' => json_encode($body)
+    );
+
+    $response = $http->request($url, $data);
+    $body = json_decode($response['body']);
+
+    if (property_exists($body, 'errors')) {
+        $this->edebug('Error in getting template data');
+        $this->setError($body->errors);
+        return false;
+    }
+
+    if (property_exists($body, 'results')) {
+      return $body->results;
+        return $body->results;
+    } else {
+        $this->edebug('API response is unknown');
+        $this->setError('Unknown response');
+        return false;
+    }
+  }
+
+}

--- a/templates.class.php
+++ b/templates.class.php
@@ -11,7 +11,6 @@ class SparkPostTemplates {
     $this->mailer = $mailer;
   }
 
-
   public function preview($id, $substitution_data){
     $url = "{$this->endpoint}/{$id}/preview?draft=false";
 

--- a/templates.class.php
+++ b/templates.class.php
@@ -15,7 +15,6 @@ class SparkPostTemplates {
 
   public function preview($id, $substitution_data){
     $url = "{$this->endpoint}/{$id}/preview?draft=false";
-    $http = $this->mailer->get_http_lib();
 
     $body = array(
       'substitution_data' => $substitution_data
@@ -31,7 +30,7 @@ class SparkPostTemplates {
     $this->mailer->debug('Making template API request');
     $this->mailer->debug(print_r($data, true));
 
-    $response = $http->request($url, $data);
+    $response = $this->mailer->request($url, $data);
     $this->mailer->debug('Template API request completed');
     $this->mailer->check_permission_error($response, 'Templates: Read/Write');
 

--- a/templates.class.php
+++ b/templates.class.php
@@ -12,8 +12,7 @@ class SparkPostTemplates {
     $this->settings = SparkPost::get_settings();
   }
 
-  protected function get_request_headers($hide_api_key = false)
-  {
+  protected function get_request_headers($hide_api_key = false){
       $api_key = apply_filters('wpsp_api_key', $this->settings['password']);
 
       return apply_filters('wpsp_request_headers', array(
@@ -32,28 +31,27 @@ class SparkPostTemplates {
     );
 
     $data = array(
-        'method' => 'POST',
-        'timeout' => 15,
-        'headers' => $this->get_request_headers(),
-        'body' => json_encode($body)
+      'method' => 'POST',
+      'timeout' => 15,
+      'headers' => $this->get_request_headers(),
+      'body' => json_encode($body)
     );
 
     $response = $http->request($url, $data);
     $body = json_decode($response['body']);
 
     if (property_exists($body, 'errors')) {
-        $this->edebug('Error in getting template data');
-        $this->setError($body->errors);
-        return false;
+      $this->edebug('Error in getting template data');
+      $this->setError($body->errors);
+      return false;
     }
 
     if (property_exists($body, 'results')) {
       return $body->results;
-        return $body->results;
     } else {
-        $this->edebug('API response is unknown');
-        $this->setError('Unknown response');
-        return false;
+      $this->edebug('API response is unknown');
+      $this->setError('Unknown response');
+      return false;
     }
   }
 

--- a/tests/phpunit.xml.dist
+++ b/tests/phpunit.xml.dist
@@ -18,6 +18,7 @@
 			<file>../mailer.smtp.class.php</file>
 			<file>../mailer.http.class.php</file>
 			<file>../admin.widget.class.php</file>
+			<file>../templates.class.php</file>
 		</whitelist>
 	</filter>
 	<logging>

--- a/tests/specs/bootstrap.php
+++ b/tests/specs/bootstrap.php
@@ -18,6 +18,7 @@ require_once $_tests_dir . '/includes/functions.php';
  */
 function _manually_load_plugin() {
 	require BASE_DIR . '/wordpress-sparkpost.php';
+	require BASE_DIR . '/templates.class.php';
 	require BASE_DIR . '/mailer.http.class.php';
 }
 

--- a/tests/specs/test-mailer.http.class.php
+++ b/tests/specs/test-mailer.http.class.php
@@ -351,7 +351,9 @@ class TestHttpMailer extends \WP_UnitTestCase {
         ),
         'subject' => 'test subject',
         'headers' => array(),
-        'html'  => '<h1>Hello there<h1>'
+        'html'  => '<h1>Hello there<h1>',
+        'text'  => 'hello there',
+        'reply_to'  => 'me@hello.com'
     );
     $attachments_data = [
       'name'  => 'php-wordpress-sparkpost.txt',
@@ -411,6 +413,8 @@ class TestHttpMailer extends \WP_UnitTestCase {
         ],
         'subject' => 'test subject',
         'html'  => '<h1>Hello there<h1>',
+        'text'  => 'hello there',
+        'reply_to'  => 'me@hello.com',
         'attachments' => $attachments_data
       ]
     ];

--- a/tests/specs/test-templates.class.php
+++ b/tests/specs/test-templates.class.php
@@ -41,6 +41,12 @@ class TestTemplates extends \WP_UnitTestCase {
         ->method('request')
         ->will($this->returnValue($response));
 
+      $mailer->expects($this->never())
+        ->method('error');
+
+      $mailer->expects($this->exactly(3))
+        ->method('debug');
+
       $templateObj = new SparkPostTemplates($mailer);
       $result = $templateObj->preview('abcd', array());
       $this->assertEquals($result->subject, 'test subject');
@@ -69,6 +75,13 @@ class TestTemplates extends \WP_UnitTestCase {
         ->method('request')
         ->will($this->returnValue($response));
 
+      $mailer->expects($this->once())
+        ->method('error');
+
+      $mailer->expects($this->exactly(4))
+        ->method('debug');
+
+
       $templateObj = new SparkPostTemplates($mailer);
       $result = $templateObj->preview('abcd', array());
       $this->assertEquals($result, false);
@@ -90,6 +103,12 @@ class TestTemplates extends \WP_UnitTestCase {
       $mailer->expects($this->once())
         ->method('request')
         ->will($this->returnValue($response));
+
+      $mailer->expects($this->once())
+        ->method('error');
+
+      $mailer->expects($this->exactly(4))
+        ->method('debug');
 
       $templateObj = new SparkPostTemplates($mailer);
       $result = $templateObj->preview('abcd', array());

--- a/tests/specs/test-templates.class.php
+++ b/tests/specs/test-templates.class.php
@@ -1,0 +1,98 @@
+<?php
+/**
+* @package wp-sparkpost
+*/
+namespace WPSparkPost;
+
+class TestTemplates extends \WP_UnitTestCase {
+    function test_it_should_set_mailer_obj(){
+      $mailer = new SparkPostHTTPMailer();
+      $templateObj = new SparkPostTemplates($mailer);
+
+      $this->assertTrue($templateObj->mailer instanceof SparkPostHTTPMailer);
+    }
+
+    function test_preview_returns_template_data() {
+      $mailer = $this->getMockBuilder('WPSparkPost\SparkPostHTTPMailer')
+        ->setMethods(array('request', 'get_request_headers', 'error', 'debug'))
+        ->getMock();
+
+      $response = array(
+        'response'  => array(
+          'code'  => 200
+        ),
+        'headers' => array(),
+        'body' =>  json_encode(array(
+          'results' => array(
+              'from' => array(
+                  'from' =>   'me@hello.com',
+                  'from_name' => 'me'
+              ),
+              'subject' => 'test subject',
+              'headers' => array(),
+              'html'  => '<h1>Hello there<h1>',
+              'text'  => 'hello there',
+              'reply_to'  => 'me@hello.com'
+          )
+        ))
+      );
+
+      $mailer->expects($this->once())
+        ->method('request')
+        ->will($this->returnValue($response));
+
+      $templateObj = new SparkPostTemplates($mailer);
+      $result = $templateObj->preview('abcd', array());
+      $this->assertEquals($result->subject, 'test subject');
+      $this->assertEquals($result->html, '<h1>Hello there<h1>');
+      $this->assertEquals($result->text, 'hello there');
+    }
+
+    function test_preview_returns_false_on_error() {
+      $mailer = $this->getMockBuilder('WPSparkPost\SparkPostHTTPMailer')
+        ->setMethods(array('request', 'get_request_headers', 'error', 'debug'))
+        ->getMock();
+
+      $response = array(
+        'response'  => array(
+          'code'  => 200
+        ),
+        'headers' => array(),
+        'body' =>  json_encode(array(
+          'errors' => array(
+            'some interesting error'
+          )
+        ))
+      );
+
+      $mailer->expects($this->once())
+        ->method('request')
+        ->will($this->returnValue($response));
+
+      $templateObj = new SparkPostTemplates($mailer);
+      $result = $templateObj->preview('abcd', array());
+      $this->assertEquals($result, false);
+    }
+
+    function test_preview_returns_false_on_unknown_error() {
+      $mailer = $this->getMockBuilder('WPSparkPost\SparkPostHTTPMailer')
+        ->setMethods(array('request', 'get_request_headers', 'error', 'debug'))
+        ->getMock();
+
+      $response = array(
+        'response'  => array(
+          'code'  => 200
+        ),
+        'headers' => array(),
+        'body' =>  json_encode(array('unknown_key' => 'unknown result'))
+      );
+
+      $mailer->expects($this->once())
+        ->method('request')
+        ->will($this->returnValue($response));
+
+      $templateObj = new SparkPostTemplates($mailer);
+      $result = $templateObj->preview('abcd', array());
+      $this->assertEquals($result, false);
+    }
+}

--- a/wordpress-sparkpost.php
+++ b/wordpress-sparkpost.php
@@ -35,6 +35,3 @@ if (SparkPost::get_setting('enable_sparkpost')) {
         add_filter('wp_mail', array($sp, 'init_sp_http_mailer'));
     }
 }
-define('WP_DEBUG', true);
-ini_set('display_errors', 1);
-error_reporting(E_ALL);

--- a/wordpress-sparkpost.php
+++ b/wordpress-sparkpost.php
@@ -35,3 +35,6 @@ if (SparkPost::get_setting('enable_sparkpost')) {
         add_filter('wp_mail', array($sp, 'init_sp_http_mailer'));
     }
 }
+define('WP_DEBUG', true);
+ini_set('display_errors', 1);
+error_reporting(E_ALL);


### PR DESCRIPTION
WIP for #97 

**Here is what it does**
- Checks if the email is using template and an attachment is provided
- If true, it prepares the substitution data, hits template's preview endpoint and get's the substituted template
- Then it makes a transmission api call without template but use the previous rendered contents (which already has template data) + attachments

🎉 

Things to do:

- [x] Add notes that customer should add template permission to api key

- [x] Notify users in case if API does not have permission

- [x] Add unit tests
