### PR TITLE
Allow String Attachments. Referencing SparkPost/wordpress-sparkpost#132

### DIFF
--- a/mailer.http.class.php
+++ b/mailer.http.class.php
@@ -219,9 +219,14 @@ class SparkPostHTTPMailer extends \PHPMailer
         return base64_encode($data);
     }
 
-    protected function read_attachment($path)
+    protected function read_attachment($data)
     {
-        return file_get_contents($path);
+        if ( file_exists( $data ) ) {
+            return file_get_contents($data);
+        }
+        else {
+            return $data;
+        }
     }
 
     public function isMail()

--- a/mailer.http.class.php
+++ b/mailer.http.class.php
@@ -221,7 +221,9 @@ class SparkPostHTTPMailer extends \PHPMailer
 
     protected function read_attachment($data)
     {
-        if ( file_exists( $data ) ) {
+        // If the provided String is a File Path, load the File Contents. If not, assume the String is the contents
+        // This allows PHPMailer's addStringAttachment() method to work thereby avoiding the need to store a file on the server before attaching it
+        if ( is_file( $data ) ) {
             return file_get_contents($data);
         }
         else {


### PR DESCRIPTION
This allows Attachments that have been added using PHPMailer's `addStringAttachment()` method to be sent properly via the HTTP API.

An example can be seen in #132.