### PR TITLE
EU API and SMTP endpoints

### DIFF
--- a/admin.widget.class.php
+++ b/admin.widget.class.php
@@ -262,6 +262,7 @@ class SparkPostAdmin
         add_settings_field('sending_method', 'Method*', array($this, 'render_sending_method_field'), 'sp-options-basic', 'general');
         add_settings_field('password', 'API Key*', array($this, 'render_password_field'), 'sp-options-basic', 'general');
         add_settings_field('template', 'Template', array($this, 'render_template_field'), 'sp-options-basic', 'general');
+        add_settings_field('location', 'API Location', array($this, 'render_location_field'), 'sp-options-basic', 'general' );
 
         add_settings_section('overrides', 'Overrides', null, 'sp-options-overrides');
         add_settings_field('from_name', 'From name', array($this, 'render_from_name_field'), 'sp-options-overrides', 'overrides');
@@ -287,6 +288,12 @@ class SparkPostAdmin
             $new_input['template'] = sanitize_text_field($input['template']);
         } else {
             $new_input['template'] = '';
+        }
+
+        if (isset($input['location'])) {
+            $new_input['location'] = sanitize_text_field($input['location']);
+        } else {
+            $new_input['location'] = '';
         }
 
         if (empty($input['password'])) {
@@ -444,6 +451,16 @@ class SparkPostAdmin
         <option value="api" ' . (($selected_method == 'api') ? 'selected' : '') . '>HTTP API (Default)</option>
         <option value="smtp587" ' . (($selected_method == 'smtp' && $selected_port == 587) ? 'selected' : '') . '>SMTP (Port 587)</option>
         <option value="smtp2525" ' . (($selected_method == 'smtp' && $selected_port == 2525) ? 'selected' : '') . '>SMTP (Port 2525)</option>
+        </select>';
+    }
+
+    public function render_location_field()
+    {
+        $selected = !empty($this->settings['location']) ? esc_attr($this->settings['location']) : '';
+
+        echo '<select name="sp_settings_basic[location]">
+        <option value="" ' . (($selected === '') ? 'selected' : '') . '>Worldwide</option>
+        <option value="eu" ' . (($selected === 'eu') ? 'selected' : '') . '>EU</option>
         </select>';
     }
 

--- a/admin.widget.class.php
+++ b/admin.widget.class.php
@@ -261,8 +261,8 @@ class SparkPostAdmin
         add_settings_field('enable_sparkpost', 'Enable*', array($this, 'render_enable_sparkpost_field'), 'sp-options-basic', 'general');
         add_settings_field('sending_method', 'Method*', array($this, 'render_sending_method_field'), 'sp-options-basic', 'general');
         add_settings_field('password', 'API Key*', array($this, 'render_password_field'), 'sp-options-basic', 'general');
-        add_settings_field('template', 'Template', array($this, 'render_template_field'), 'sp-options-basic', 'general');
         add_settings_field('location', 'API Location', array($this, 'render_location_field'), 'sp-options-basic', 'general' );
+        add_settings_field('template', 'Template', array($this, 'render_template_field'), 'sp-options-basic', 'general');
 
         add_settings_section('overrides', 'Overrides', null, 'sp-options-overrides');
         add_settings_field('from_name', 'From name', array($this, 'render_from_name_field'), 'sp-options-overrides', 'overrides');

--- a/mailer.http.class.php
+++ b/mailer.http.class.php
@@ -10,7 +10,7 @@ require_once WPSP_PLUGIN_DIR . '/templates.class.php';
 
 class SparkPostHTTPMailer extends \PHPMailer
 {
-    public $endpoint = 'https://api.sparkpost.com/api/v1/transmissions';
+    public $endpoint;
     public $wp_mail_args;
     private $settings;
 
@@ -22,6 +22,8 @@ class SparkPostHTTPMailer extends \PHPMailer
     {
         $this->settings = SparkPost::get_settings();
         $this->template = new SparkPostTemplates($this);
+        $location = apply_filters('sp_location', 'us');
+        $this->endpoint = SparkPost::get_hostname($location, 'api') . '/api/v1/transmissions';
 
         parent::__construct($exceptions);
         do_action('wpsp_init_mailer', $this);
@@ -492,7 +494,6 @@ class SparkPostHTTPMailer extends \PHPMailer
     public function request($endpoint, $data)
     {
         $http = apply_filters('wpsp_get_http_lib', _wp_http_get_object());
-        $endpoint = apply_filters('sp_api_location', $endpoint);
 
         $this->debug(sprintf('Request headers: %s', print_r($this->get_request_headers(true), true)));
         $this->debug(sprintf('Request body: %s', $data['body']));

--- a/mailer.http.class.php
+++ b/mailer.http.class.php
@@ -492,6 +492,7 @@ class SparkPostHTTPMailer extends \PHPMailer
     public function request($endpoint, $data)
     {
         $http = apply_filters('wpsp_get_http_lib', _wp_http_get_object());
+        $endpoint = apply_filters('sp_api_location', $endpoint);
 
         $this->debug(sprintf('Request headers: %s', print_r($this->get_request_headers(true), true)));
         $this->debug(sprintf('Request body: %s', $data['body']));

--- a/mailer.http.class.php
+++ b/mailer.http.class.php
@@ -22,8 +22,7 @@ class SparkPostHTTPMailer extends \PHPMailer
     {
         $this->settings = SparkPost::get_settings();
         $this->template = new SparkPostTemplates($this);
-        $location = apply_filters('sp_location', 'us');
-        $this->endpoint = SparkPost::get_hostname($location, 'api') . '/api/v1/transmissions';
+        $this->endpoint = apply_filters('sp_hostname', 'api') . '/api/v1/transmissions';
 
         parent::__construct($exceptions);
         do_action('wpsp_init_mailer', $this);

--- a/mailer.smtp.class.php
+++ b/mailer.smtp.class.php
@@ -39,7 +39,7 @@ class SparkPostSMTPMailer
         $phpmailer->isSMTP();
         $phpmailer->SMTPSecure = 'tls';
         $phpmailer->Port = !empty($settings['port']) ? intval($settings['port']) : 587;
-        $phpmailer->Host = 'smtp.sparkpostmail.com';
+        $phpmailer->Host = apply_filters('sp_smtp_location', 'smtp.sparkpostmail.com');
         $phpmailer->SMTPAuth = true;
         $phpmailer->Username = 'SMTP_Injection';
         $phpmailer->Password = apply_filters('wpsp_api_key', $settings['password']);

--- a/mailer.smtp.class.php
+++ b/mailer.smtp.class.php
@@ -10,7 +10,6 @@ if (!defined('ABSPATH')) exit();
  */
 class SparkPostSMTPMailer
 {
-
     public function __construct()
     {
         add_action('phpmailer_init', array($this, 'configure_phpmailer'), 2);
@@ -36,10 +35,13 @@ class SparkPostSMTPMailer
             )
         );
 
+        $location = apply_filters('sp_location', 'us');
+        $host = SparkPost::get_hostname($location, 'smtp');
+
         $phpmailer->isSMTP();
         $phpmailer->SMTPSecure = 'tls';
         $phpmailer->Port = !empty($settings['port']) ? intval($settings['port']) : 587;
-        $phpmailer->Host = apply_filters('sp_smtp_location', 'smtp.sparkpostmail.com');
+        $phpmailer->Host = $host;
         $phpmailer->SMTPAuth = true;
         $phpmailer->Username = 'SMTP_Injection';
         $phpmailer->Password = apply_filters('wpsp_api_key', $settings['password']);

--- a/mailer.smtp.class.php
+++ b/mailer.smtp.class.php
@@ -35,13 +35,10 @@ class SparkPostSMTPMailer
             )
         );
 
-        $location = apply_filters('sp_location', 'us');
-        $host = SparkPost::get_hostname($location, 'smtp');
-
         $phpmailer->isSMTP();
         $phpmailer->SMTPSecure = 'tls';
         $phpmailer->Port = !empty($settings['port']) ? intval($settings['port']) : 587;
-        $phpmailer->Host = $host;
+        $phpmailer->Host = apply_filters('sp_hostname', 'smtp');
         $phpmailer->SMTPAuth = true;
         $phpmailer->Username = 'SMTP_Injection';
         $phpmailer->Password = apply_filters('wpsp_api_key', $settings['password']);

--- a/sparkpost.class.php
+++ b/sparkpost.class.php
@@ -40,6 +40,8 @@ class SparkPost
         if (self::get_setting('enable_sparkpost')) { //no need to register this hooks if plugin is disabled
             add_filter('wp_mail_from', array($this, 'set_from_email'));
             add_filter('wp_mail_from_name', array($this, 'set_from_name'));
+            add_filter('sp_api_location', array($this, 'location_endpoint'));
+            add_filter('sp_smtp_location', array($this, 'location_endpoint'));
         }
 
         $this->db_version = '1.0.0';
@@ -151,6 +153,26 @@ class SparkPost
         }
 
         return apply_filters('wpsp_sender_email', $email);
+    }
+
+    public function location_endpoint($endpoint)
+    {
+        $location = !empty($this->settings['location']) ? esc_attr($this->settings['location']) : '';
+        if ($location === 'eu') {
+            $endpoint = str_replace(
+                array(
+                    'https://api',
+                    'smtp.sparkpostmail.com'
+                ),
+                array(
+                    'https://api.eu',
+                    'smtp.eu.sparkpostmail.com'
+                ),
+                $endpoint
+            );
+        }
+
+        return $endpoint;
     }
 
     static function obfuscate_api_key($api_key)

--- a/sparkpost.class.php
+++ b/sparkpost.class.php
@@ -25,7 +25,7 @@ class SparkPost
         'location' => 'us'
     );
 
-    protected static $hostnames = array(
+    protected $hostnames = array(
         'us' => array(
             'api' => 'https://api.sparkpost.com',
             'smtp' => 'smtp.sparkpostmail.com'
@@ -52,7 +52,7 @@ class SparkPost
         if (self::get_setting('enable_sparkpost')) { //no need to register this hooks if plugin is disabled
             add_filter('wp_mail_from', array($this, 'set_from_email'));
             add_filter('wp_mail_from_name', array($this, 'set_from_name'));
-            add_filter('sp_location', array($this, 'hostname_location'));
+            add_filter('sp_hostname', array($this, 'get_hostname'));
         }
 
         $this->db_version = '1.0.0';
@@ -166,14 +166,10 @@ class SparkPost
         return apply_filters('wpsp_sender_email', $email);
     }
 
-    public function hostname_location($location = 'us')
+    public function get_hostname($type = 'api')
     {
-        return !empty($this->settings['location']) ? esc_attr($this->settings['location']) : $location;
-    }
-
-    static function get_hostname($location = 'us', $type = 'api')
-    {
-        return apply_filters('sp_hostname', self::$hostnames[$location][$type]);
+        $location = !empty($this->settings['location']) ? esc_attr($this->settings['location']) : 'us';
+        return $this->hostnames[$location][$type];
     }
 
     static function obfuscate_api_key($api_key)

--- a/templates.class.php
+++ b/templates.class.php
@@ -7,11 +7,13 @@ if (!defined('ABSPATH')) exit();
 
 class SparkPostTemplates
 {
-    public $endpoint = 'https://api.sparkpost.com/api/v1/templates';
+    public $endpoint;
 
     public function __construct($mailer)
     {
         $this->mailer = $mailer;
+        $location = apply_filters('sp_location', 'us');
+        $this->endpoint = SparkPost::get_hostname($location, 'api') . '/api/v1/templates';
     }
 
     public function preview($id, $substitution_data)

--- a/templates.class.php
+++ b/templates.class.php
@@ -12,8 +12,8 @@ class SparkPostTemplates
     public function __construct($mailer)
     {
         $this->mailer = $mailer;
-        $location = apply_filters('sp_location', 'us');
-        $this->endpoint = SparkPost::get_hostname($location, 'api') . '/api/v1/templates';
+        
+        $this->endpoint = apply_filters('sp_hostname', 'api') . '/api/v1/templates';
     }
 
     public function preview($id, $substitution_data)

--- a/templates.class.php
+++ b/templates.class.php
@@ -16,7 +16,8 @@ class SparkPostTemplates
 
     public function preview($id, $substitution_data)
     {
-        $url = "{$this->endpoint}/{$id}/preview?draft=false";
+        $endpoint = apply_filters('sp_api_location', $this->endpoint);
+        $url = "{$endpoint}/{$id}/preview?draft=false";
 
         $body = array(
             'substitution_data' => $substitution_data

--- a/tests/specs/test-sparkpost.class.php
+++ b/tests/specs/test-sparkpost.class.php
@@ -28,4 +28,26 @@ class TestSparkPost extends \WP_UnitTestCase {
         $this->assertTrue(SparkPost::is_sandbox('testing@sparkpostbox.com'));
         $this->assertFalse(SparkPost::is_sandbox('testing@mydoman.com'));
     }
+
+    function test_default_location() {
+        $this->assertTrue($this->SparkPost->settings['location'] === 'us');
+        $this->assertTrue($this->SparkPost->hostname_location() === 'us');
+    }
+
+    function test_eu_location() {
+        $this->SparkPost->settings['location'] = 'eu';
+
+        $this->assertTrue($this->SparkPost->hostname_location() === 'eu');
+    }
+
+    function test_get_hostname() {
+        $us_api = 'https://api.sparkpost.com';
+        $us_smtp = 'smtp.sparkpostmail.com';
+
+        $this->assertTrue(SparkPost::get_hostname('us', 'api') === $us_api);
+        $this->assertTrue(SparkPost::get_hostname() === $us_api);
+        $this->assertTrue(SparkPost::get_hostname('us', 'smtp') === 'smtp.sparkpostmail.com');
+        $this->assertTrue(SparkPost::get_hostname('eu', 'api') === 'https://api.eu.sparkpost.com');
+        $this->assertTrue(SparkPost::get_hostname('eu', 'smtp') === 'smtp.eu.sparkpostmail.com');
+    }
 }

--- a/tests/specs/test-sparkpost.class.php
+++ b/tests/specs/test-sparkpost.class.php
@@ -29,25 +29,22 @@ class TestSparkPost extends \WP_UnitTestCase {
         $this->assertFalse(SparkPost::is_sandbox('testing@mydoman.com'));
     }
 
-    function test_default_location() {
-        $this->assertTrue($this->SparkPost->settings['location'] === 'us');
-        $this->assertTrue($this->SparkPost->hostname_location() === 'us');
-    }
-
-    function test_eu_location() {
-        $this->SparkPost->settings['location'] = 'eu';
-
-        $this->assertTrue($this->SparkPost->hostname_location() === 'eu');
-    }
-
-    function test_get_hostname() {
+    function test_us_hostnames() {
         $us_api = 'https://api.sparkpost.com';
         $us_smtp = 'smtp.sparkpostmail.com';
 
-        $this->assertTrue(SparkPost::get_hostname('us', 'api') === $us_api);
-        $this->assertTrue(SparkPost::get_hostname() === $us_api);
-        $this->assertTrue(SparkPost::get_hostname('us', 'smtp') === 'smtp.sparkpostmail.com');
-        $this->assertTrue(SparkPost::get_hostname('eu', 'api') === 'https://api.eu.sparkpost.com');
-        $this->assertTrue(SparkPost::get_hostname('eu', 'smtp') === 'smtp.eu.sparkpostmail.com');
+        $this->assertTrue($this->SparkPost->get_hostname('api') === $us_api);
+        $this->assertTrue($this->SparkPost->get_hostname() === $us_api);
+        $this->assertTrue($this->SparkPost->get_hostname('smtp') === 'smtp.sparkpostmail.com');
+    }
+
+    function test_eu_hostnames() {
+        $eu_api = 'https://api.eu.sparkpost.com';
+        $eu_smtp = 'smtp.eu.sparkpostmail.com';
+
+        $this->SparkPost->settings['location'] = 'eu';
+
+        $this->assertTrue($this->SparkPost->get_hostname('api') === 'https://api.eu.sparkpost.com');
+        $this->assertTrue($this->SparkPost->get_hostname('smtp') === 'smtp.eu.sparkpostmail.com');
     }
 }

--- a/tests/specs/test-wordpress-sparkpost.php
+++ b/tests/specs/test-wordpress-sparkpost.php
@@ -2,21 +2,20 @@
 /**
  * @package wp-sparkpost
  */
-
 namespace WPSparkPost;
 
 class TestWordPressSparkPost extends \WP_UnitTestCase {
 
-	function test_plugin_dir_constants() {
-		$this->assertTrue( defined('WPSP_PLUGIN_DIR') );
-	}
+    function test_plugin_dir_constants() {
+        $this->assertTrue( defined('WPSP_PLUGIN_DIR') );
+    }
 
-  function test_plugin_path_constants() {
-		$this->assertTrue( defined('WPSP_PLUGIN_PATH') );
-    $this->assertTrue( strpos(WPSP_PLUGIN_PATH, '/wordpress-sparkpost/wordpress-sparkpost.php') !== false); // full path not available in test mode
-	}
+    function test_plugin_path_constants() {
+        $this->assertTrue( defined('WPSP_PLUGIN_PATH') );
+        $this->assertTrue( strpos(WPSP_PLUGIN_PATH, '/wordpress-sparkpost/wordpress-sparkpost.php') !== false); // full path not available in test mode
+    }
 
-  function test_SparkPost_class_loaded() {
-    $this->assertTrue( class_exists('WPSparkPost\SparkPost'));
-  }
+    function test_SparkPost_class_loaded() {
+        $this->assertTrue( class_exists('WPSparkPost\SparkPost'));
+    }
 }


### PR DESCRIPTION
After encountering an error when sending test emails, I contacted SparkPost support who informed me that there were different API & SMTP endpoints for SparkPost EU.

I've added a new API location field to the admin area (defaulting to Worldwide) and set up a new filter on the two endpoints.

One thing to note, and I'm not sure if this is a SparkPost internal thing or something else that needs to be worked on, SMTP emails throw the following error on PHP 7.1.

```
Warning: stream_socket_enable_crypto(): Peer certificate CN=`*.sparkpostmail.com' did not match expected CN=`smtp.eu.sparkpostmail.com' in /wp-includes/class-smtp.php on line 368
```

The support team advised that the SMTP host should be: `smtp.eu.sparkpostmail.com`, so I'm not certain as to why this error is occurring. If it's an internal error, I can always update the PR to drop SMTP support in EU locations.