### PR TITLE
convert to json obj

### DIFF
--- a/mailer.http.class.php
+++ b/mailer.http.class.php
@@ -117,6 +117,8 @@ class SparkPostHTTPMailer extends \PHPMailer
 
         $attachments = $this->get_attachments();
 
+        $content_headers = json_decode(json_encode($this->get_headers(), JSON_FORCE_OBJECT));
+
         // pass through either stored template or inline content
         if (!empty($template_id)) {
             // stored template
@@ -129,7 +131,7 @@ class SparkPostHTTPMailer extends \PHPMailer
                 $body['content'] = array(
                     'from' => (array)$preview_contents->from,
                     'subject' => (string)$preview_contents->subject,
-                    'headers' => (array)$this->get_headers()
+                    'headers' => $content_headers
                 );
 
                 if (property_exists($preview_contents, 'text')) {
@@ -153,7 +155,7 @@ class SparkPostHTTPMailer extends \PHPMailer
             $body['content'] = array(
                 'from' => $sender,
                 'subject' => $this->Subject,
-                'headers' => $this->get_headers()
+                'headers' => $content_headers
             );
 
             if ($replyTo) {

--- a/mailer.http.class.php
+++ b/mailer.http.class.php
@@ -117,7 +117,7 @@ class SparkPostHTTPMailer extends \PHPMailer
 
         $attachments = $this->get_attachments();
 
-        $content_headers = json_decode(json_encode($this->get_headers(), JSON_FORCE_OBJECT));
+        $content_headers = $this->get_headers();
 
         // pass through either stored template or inline content
         if (!empty($template_id)) {
@@ -130,8 +130,7 @@ class SparkPostHTTPMailer extends \PHPMailer
                 }
                 $body['content'] = array(
                     'from' => (array)$preview_contents->from,
-                    'subject' => (string)$preview_contents->subject,
-                    'headers' => $content_headers
+                    'subject' => (string)$preview_contents->subject
                 );
 
                 if (property_exists($preview_contents, 'text')) {
@@ -154,8 +153,7 @@ class SparkPostHTTPMailer extends \PHPMailer
             // inline content
             $body['content'] = array(
                 'from' => $sender,
-                'subject' => $this->Subject,
-                'headers' => $content_headers
+                'subject' => $this->Subject
             );
 
             if ($replyTo) {
@@ -174,6 +172,10 @@ class SparkPostHTTPMailer extends \PHPMailer
                     $body['content']['html'] = $this->Body;
                     break;
             }
+        }
+
+        if(!empty($content_headers)) {
+            $body['content']['headers'] = $content_headers;
         }
 
         if (sizeof($attachments)) {

--- a/readme.txt
+++ b/readme.txt
@@ -15,7 +15,7 @@ When the SparkPost plugin is enabled, all outgoing email from your WordPress ins
 
 **Requirements**
 - PHP 5.4 or later
-- WordPress 4.3 or later
+- WordPress 5.5 or later
 
 
 == Installation ==

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: sparkpost, rajuru
 Tags: sparkpost, smtp, wp_mail, mail, email
 Requires at least: 5.5
 Tested up to: 5.5
-Stable tag: 3.2.0
+Stable tag: 3.2.1
 License: GPLv2 or later
 
 Send all your email from WordPress through SparkPost, the most advanced email delivery service.
@@ -51,6 +51,10 @@ Visit plugin's [official issue tracker](https://github.com/SparkPost/wordpress-s
 
 
 == Changelog ==
+= 3.2.1 =
+- Fixed invalid data format/type bug ([153](https://github.com/SparkPost/wordpress-sparkpost/pull/153))
+- Tested up to Wordpress v5.5.0
+
 = 3.2.0 =
 - Add support for EU hostnames ([141](https://github.com/SparkPost/wordpress-sparkpost/pull/141))
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === SparkPost ===
 Contributors: sparkpost, rajuru
 Tags: sparkpost, smtp, wp_mail, mail, email
-Requires at least: 4.3
-Tested up to: 4.9.5
+Requires at least: 5.5
+Tested up to: 5.5
 Stable tag: 3.2.0
 License: GPLv2 or later
 

--- a/wordpress-sparkpost.php
+++ b/wordpress-sparkpost.php
@@ -18,7 +18,7 @@ if (!defined('ABSPATH')) exit();
 
 define('WPSP_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('WPSP_PLUGIN_PATH', WPSP_PLUGIN_DIR . basename(__FILE__));
-define('WPSP_PLUGIN_VERSION', '3.2.0');
+define('WPSP_PLUGIN_VERSION', '3.2.1');
 
 require_once(WPSP_PLUGIN_DIR . 'sparkpost.class.php');
 


### PR DESCRIPTION
Seems it's requiring json object instead of json array representation. not sure why! is something changed at sparkpost api level? In such case it's not wordpress 5.5 related!

- I've used json_encode to convert to json object but as it returns string, I had to decode again. I've used php after long long time and no idea if there is a better way to convert to json obj. 
- need to verify if this fix works in older version of wordpress. if not, we've two options:
-- keep older format for older wordpress version (if it's version related)
-- change minimum required version for wordpress (which is what I did in this PR)
- `JSON_FORCE_OBJECT` requires php 5.3+ (which should be fine but just need to make sure with php EOL guideline)


Please feel free to make any changes to this PR. If you need me to make other changes, I can aim that end of the day or tomorrow. 


re: 2nd issue of
> Warning: Invalid argument supplied for foreach() in /home/customer/www/fluxwebdesign7.be/public_html/customer/testdirk/wp-content/plugins/sparkpost/mailer.http.class.php on line 453

may be for some reason `$this->createHeader` is returning something unexpected! it needs more investigation! but this is just an warning not an actual error. 

