### PR TITLE
FE-1168: SparkPost logo is broken on Wordpress plugin admin page

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,16 +13,10 @@ branches:
     - master
 
 php:
-  - 5.6
   - 7.0
 
 env:
-  - WP_VERSION=latest WP_MULTISITE=0
-  - WP_VERSION=4.3 WP_MULTISITE=0
-  - WP_VERSION=4.4 WP_MULTISITE=0
-  - WP_VERSION=4.5 WP_MULTISITE=0
-  - WP_VERSION=4.6 WP_MULTISITE=0
-  - WP_VERSION=4.7 WP_MULTISITE=0
+  - WP_VERSION=5.5 WP_MULTISITE=0
 
 before_script:
   - cd tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: php
 
+services:
+  - mysql
+
 notifications:
   email:
     on_success: never

--- a/deploy.sh
+++ b/deploy.sh
@@ -76,7 +76,7 @@ rm -rf $SVNPATH/assets/*
 
 echo "Exporting the HEAD of master from git to the trunk of SVN"
 git checkout-index -a -f --prefix=$SVNPATH/trunk/
-git checkout-index -a -f --prefix=$SVNPATH/ assets/*
+git checkout-index -f --prefix=$SVNPATH/ assets/*
 rm -rf $SVNPATH/trunk/assets
 
 echo "Ignoring github specific files and deployment script"

--- a/mailer.http.class.php
+++ b/mailer.http.class.php
@@ -123,7 +123,7 @@ class SparkPostHTTPMailer extends \PHPMailer\PHPMailer\PHPMailer
         if (!empty($template_id)) {
             // stored template
             $substitution_data = $this->get_template_substitutes($sender, $replyTo);
-            if (sizeof($attachments) > 0) { //get template preview data and then send it as inline
+            if (sizeof($attachments) > 0) { // get template preview data and then send it as inline
                 $preview_contents = $this->template->preview($template_id, $substitution_data);
                 if ($preview_contents === false) {
                     return false;
@@ -132,6 +132,10 @@ class SparkPostHTTPMailer extends \PHPMailer\PHPMailer\PHPMailer
                     'from' => (array)$preview_contents->from,
                     'subject' => (string)$preview_contents->subject
                 );
+
+                if(!empty($content_headers)) {
+                    $body['content']['headers'] = $content_headers;
+                }
 
                 if (property_exists($preview_contents, 'text')) {
                     $body['content']['text'] = $preview_contents->text;
@@ -145,7 +149,7 @@ class SparkPostHTTPMailer extends \PHPMailer\PHPMailer\PHPMailer
                     $body['content']['reply_to'] = $preview_contents->reply_to;
                 }
 
-            } else { // simply subsititute template tags
+            } else { // simply substitute template tags
                 $body['content']['template_id'] = $template_id;
                 $body['substitution_data'] = $substitution_data;
             }
@@ -155,6 +159,10 @@ class SparkPostHTTPMailer extends \PHPMailer\PHPMailer\PHPMailer
                 'from' => $sender,
                 'subject' => $this->Subject
             );
+
+            if(!empty($content_headers)) {
+                $body['content']['headers'] = $content_headers;
+            }
 
             if ($replyTo) {
                 $body['content']['reply_to'] = $replyTo;
@@ -172,10 +180,6 @@ class SparkPostHTTPMailer extends \PHPMailer\PHPMailer\PHPMailer
                     $body['content']['html'] = $this->Body;
                     break;
             }
-        }
-
-        if(!empty($content_headers)) {
-            $body['content']['headers'] = $content_headers;
         }
 
         if (sizeof($attachments)) {

--- a/readme.txt
+++ b/readme.txt
@@ -14,7 +14,7 @@ The [SparkPost](https://www.sparkpost.com/) email delivery service offers best i
 When the SparkPost plugin is enabled, all outgoing email from your WordPress installation is sent through your SparkPost service.  From within [the SparkPost UI](https://app.sparkpost.com/) or [SparkPost EU UI](https://app.eu.sparkpost.com/), you can then watch your campaigns unfold live by tracking your engagement metrics, learn what your audience responds to and even integrate more deeply with your app using the SparkPost API.
 
 **Requirements**
-- PHP 5.4 or later
+- PHP 7.0 or later
 - WordPress 5.5 or later
 
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: sparkpost, rajuru
 Tags: sparkpost, smtp, wp_mail, mail, email
 Requires at least: 5.5
 Tested up to: 5.5
-Stable tag: 3.2.2
+Stable tag: 3.2.3
 License: GPLv2 or later
 
 Send all your email from WordPress through SparkPost, the most advanced email delivery service.
@@ -51,6 +51,9 @@ Visit plugin's [official issue tracker](https://github.com/SparkPost/wordpress-s
 
 
 == Changelog ==
+
+= 3.2.3 =
+- Fixed broken SparkPost logo on settings page ([157](https://github.com/SparkPost/wordpress-sparkpost/pull/157))
 
 = 3.2.2 =
 - Fixed parsing of headers and addressed class-phpmailer.php deprecation notice (for HTTP) ([156](https://github.com/SparkPost/wordpress-sparkpost/pull/156))

--- a/tests/bin/install-wp-tests.sh
+++ b/tests/bin/install-wp-tests.sh
@@ -118,7 +118,7 @@ install_db() {
 	fi
 
 	# create database
-	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
+	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS" $EXTRA
 }
 
 install_wp

--- a/tests/specs/test-mailer.http.class.php
+++ b/tests/specs/test-mailer.http.class.php
@@ -80,42 +80,52 @@ class TestHttpMailer extends \WP_UnitTestCase {
   }
 
   function test_get_headers() {
-    $raw_headers = "Date: Wed, 26 Oct 2016 23:45:32 +0000
-    To: undisclosed-recipients:;
-    From: Root User <root@localhost>
-    Subject: Hello
-    Reply-To: replyto@mydomain.com
-    Message-ID: <abcd@example.org>
-    MIME-Version: 1.0
-    Content-Type: text/plain; charset=iso-8859-1
-    Content-Transfer-Encoding: 8bit";
+    $stub = Mockery::mock($this->mailer);
+    $raw_headers = join(
+      NSA::getProperty($stub, 'LE'),
+      array(
+        'Date: Wed, 26 Oct 2016 23:45:32 +0000',
+        'To: undisclosed-recipients:;',
+        'From: Root User <root@localhost>',
+        'Subject: Hello',
+        'Reply-To: replyto@mydomain.com',
+        'Message-ID: <abcd@example.org>',
+        'MIME-Version: 1.0',
+        'Content-Type: text/plain; charset=iso-8859-1',
+        'Content-Transfer-Encoding: 8bit'
+      )
+    );
+    $stub->shouldReceive('createHeader')->andReturn($raw_headers);
+    $formatted_headers = NSA::invokeMethod($stub, 'get_headers');
 
     $expected = array(
       'Message-ID' => '<abcd@example.org>',
       'Date' => 'Wed, 26 Oct 2016 23:45:32 +0000'
     );
-    $stub = Mockery::mock($this->mailer);
-    $stub->shouldReceive('createHeader')->andReturn($raw_headers);
-    $formatted_headers = NSA::invokeMethod($stub, 'get_headers');
 
     $this->assertEquals($formatted_headers, $expected);
   }
 
 
   function test_get_headers_should_include_cc_if_exists() {
-    $raw_headers = "Date: Wed, 26 Oct 2016 23:45:32 +0000
-    Reply-To: replyto@mydomain.com";
-
-    $expected = array(
-      'Date' => 'Wed, 26 Oct 2016 23:45:32 +0000',
-      'CC' => 'hello@abc.com,Name <name@domain.com>'
-    );
     $stub = Mockery::mock($this->mailer);
+    $raw_headers = join(
+      NSA::getProperty($stub, 'LE'),
+      array(
+        'Date: Wed, 26 Oct 2016 23:45:32 +0000',
+        'Reply-To: replyto@mydomain.com'
+      )
+    );
     $stub->shouldReceive('createHeader')->andReturn($raw_headers);
     $stub->addCc('hello@abc.com');
     $stub->addCc('name@domain.com', 'Name');
 
     $formatted_headers = NSA::invokeMethod($stub, 'get_headers');
+
+    $expected = array(
+      'Date' => 'Wed, 26 Oct 2016 23:45:32 +0000',
+      'CC' => 'hello@abc.com,Name <name@domain.com>'
+    );
 
     $this->assertEquals($formatted_headers, $expected);
   }

--- a/tests/specs/test-mailer.http.class.php
+++ b/tests/specs/test-mailer.http.class.php
@@ -25,11 +25,11 @@ class TestHttpMailer extends \WP_UnitTestCase {
     $stub = Mockery::mock($this->mailer);
     $stub->shouldReceive('sparkpost_send')->andReturn('woowoo');
 
-    $this->assertTrue(NSA::invokeMethod($stub, 'mailSend', null, null) == 'woowoo');
+    $this->assertEquals(NSA::invokeMethod($stub, 'mailSend', null, null), 'woowoo');
   }
 
   function test_mailer_is_a_mailer_instance() {
-    $this->assertTrue( $this->mailer instanceof \PHPMailer );
+    $this->assertTrue( $this->mailer instanceof \PHPMailer\PHPMailer\PHPMailer );
   }
 
   function test_get_sender_with_name() {
@@ -39,7 +39,7 @@ class TestHttpMailer extends \WP_UnitTestCase {
       'email' => 'me@hello.com'
     );
 
-    $this->assertTrue(NSA::invokeMethod($this->mailer, 'get_sender') == $sender);
+    $this->assertEquals(NSA::invokeMethod($this->mailer, 'get_sender'), $sender);
   }
 
   function test_get_sender_without_name() {
@@ -48,7 +48,7 @@ class TestHttpMailer extends \WP_UnitTestCase {
       'email' => 'me@hello.com'
     );
 
-    $this->assertTrue(NSA::invokeMethod($this->mailer, 'get_sender') == $sender);
+    $this->assertEquals(NSA::invokeMethod($this->mailer, 'get_sender'), $sender);
   }
 
   function test_get_request_headers() {
@@ -57,7 +57,7 @@ class TestHttpMailer extends \WP_UnitTestCase {
       'Content-Type' => 'application/json',
       'Authorization' => ''
     );
-    $this->assertTrue(NSA::invokeMethod($this->mailer, 'get_request_headers') == $expected);
+    $this->assertEquals(NSA::invokeMethod($this->mailer, 'get_request_headers'), $expected);
 
     NSA::setProperty($this->mailer, 'settings', array('password' => 'abcd1234'));
     $expected = array(
@@ -65,7 +65,7 @@ class TestHttpMailer extends \WP_UnitTestCase {
       'Content-Type' => 'application/json',
       'Authorization' => 'abcd1234'
     );
-    $this->assertTrue(NSA::invokeMethod($this->mailer, 'get_request_headers') == $expected);
+    $this->assertEquals(NSA::invokeMethod($this->mailer, 'get_request_headers'), $expected);
   }
 
   function test_get_request_headers_obfuscate_key() {
@@ -75,7 +75,8 @@ class TestHttpMailer extends \WP_UnitTestCase {
       'Content-Type' => 'application/json',
       'Authorization' => 'abcd'.str_repeat('*', 36)
     );
-    $this->assertTrue(NSA::invokeMethod($this->mailer, 'get_request_headers', true) == $expected);
+
+    $this->assertEquals(NSA::invokeMethod($this->mailer, 'get_request_headers', true), $expected);
   }
 
   function test_get_headers() {
@@ -97,7 +98,7 @@ class TestHttpMailer extends \WP_UnitTestCase {
     $stub->shouldReceive('createHeader')->andReturn($raw_headers);
     $formatted_headers = NSA::invokeMethod($stub, 'get_headers');
 
-    $this->assertTrue($formatted_headers == $expected);
+    $this->assertEquals($formatted_headers, $expected);
   }
 
 
@@ -116,7 +117,7 @@ class TestHttpMailer extends \WP_UnitTestCase {
 
     $formatted_headers = NSA::invokeMethod($stub, 'get_headers');
 
-    $this->assertTrue($formatted_headers == $expected);
+    $this->assertEquals($formatted_headers, $expected);
   }
 
   function test_get_recipients() {
@@ -172,7 +173,7 @@ class TestHttpMailer extends \WP_UnitTestCase {
     ];
 
     $recipients = NSA::invokeMethod($this->mailer, 'get_recipients');
-    $this->assertTrue($recipients == $expected);
+    $this->assertEquals($recipients, $expected);
   }
 
   function test_get_attachments() {
@@ -190,9 +191,9 @@ class TestHttpMailer extends \WP_UnitTestCase {
   function test_isMail() {
     // test if isMail sets correct mailer
     $this->mailer->Mailer = 'abc';
-    $this->assertTrue($this->mailer->Mailer === 'abc');
+    $this->assertEquals($this->mailer->Mailer, 'abc');
     $this->mailer->isMail();
-    $this->assertTrue($this->mailer->Mailer === 'sparkpost');
+    $this->assertEquals($this->mailer->Mailer, 'sparkpost');
   }
 
   function test_get_request_body_without_template() {
@@ -250,7 +251,7 @@ class TestHttpMailer extends \WP_UnitTestCase {
     // for simpler expectation reset content.headers to empty array.
     // alternative is to stub get_headers which isn't working expectedly
     $actual['content']['headers'] = [];
-    $this->assertTrue($expected_request_body == $actual);
+    $this->assertEquals($expected_request_body, $actual);
 
     //INCLUDE REPLYTO
     $this->mailer->addReplyTo('reply@abc.com', 'reply-to');
@@ -258,7 +259,7 @@ class TestHttpMailer extends \WP_UnitTestCase {
     $actual = NSA::invokeMethod($this->mailer, 'get_request_body');
     $actual['content']['headers'] = []; //see note above
     $expected_request_body['content']['reply_to'] = 'reply-to <reply@abc.com>';
-    $this->assertTrue($expected_request_body == $actual);
+    $this->assertEquals($expected_request_body, $actual);
   }
 
   function test_get_request_body_template_in_hook_but_not_in_settings() {
@@ -279,7 +280,7 @@ class TestHttpMailer extends \WP_UnitTestCase {
 
     $body = NSA::invokeMethod($this->mailer, 'get_request_body');
     remove_filter('wpsp_template_id', $callback);
-    $this->assertTrue($body['content']['template_id'] == 'test-template');
+    $this->assertEquals($body['content']['template_id'], 'test-template');
   }
 
   function test_get_request_body_with_template() {
@@ -333,14 +334,14 @@ class TestHttpMailer extends \WP_UnitTestCase {
     ];
 
     $actual = NSA::invokeMethod($this->mailer, 'get_request_body');
-    $this->assertTrue($expected_request_body == $actual);
+    $this->assertEquals($expected_request_body, $actual);
 
     //INCLUDE REPLYTO
     $this->mailer->addReplyTo('reply@abc.com', 'reply-to');
     $this->mailer->addCustomHeader('Reply-To', 'reply-to <reply@abc.com>'); //for below version v4.6
     $actual = NSA::invokeMethod($this->mailer, 'get_request_body');
     $expected_request_body['substitution_data']['reply_to'] = 'reply-to <reply@abc.com>';
-    $this->assertTrue($expected_request_body == $actual);
+    $this->assertEquals($expected_request_body, $actual);
   }
 
   function test_get_request_body_with_template_and_attachments() {
@@ -420,7 +421,7 @@ class TestHttpMailer extends \WP_UnitTestCase {
 
     $actual = NSA::invokeMethod($mailer, 'get_request_body');
     unset($actual['content']['headers']); //to simplify assertion
-    $this->assertTrue($expected_request_body == $actual);
+    $this->assertEquals($expected_request_body, $actual);
   }
 
   function test_sparkpost_send_false_on_error() {
@@ -519,7 +520,7 @@ class TestHttpMailer extends \WP_UnitTestCase {
     ]);
 
     $body = NSA::invokeMethod($mailer, 'get_request_body');
-    $this->assertTrue($body['options']['sandbox'] == true);
+    $this->assertTrue($body['options']['sandbox']);
   }
 
   function sparkpost_send_prepare_mocks($num_rejected) {
@@ -658,10 +659,10 @@ class TestHttpMailer extends \WP_UnitTestCase {
       ->setMethods(array('debug', 'error'))
       ->getMock();
 
-    $this->assertTrue($mailer->check_permission_error($response, 'test_perm') === true);
+    $this->assertTrue($mailer->check_permission_error($response, 'test_perm'));
 
     $response['response']['code'] = 200;
-    $this->assertTrue($mailer->check_permission_error($response, 'test_perm') === false);
+    $this->assertFalse($mailer->check_permission_error($response, 'test_perm'));
   }
 
 

--- a/wordpress-sparkpost.php
+++ b/wordpress-sparkpost.php
@@ -18,7 +18,7 @@ if (!defined('ABSPATH')) exit();
 
 define('WPSP_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('WPSP_PLUGIN_PATH', WPSP_PLUGIN_DIR . basename(__FILE__));
-define('WPSP_PLUGIN_VERSION', '3.2.2');
+define('WPSP_PLUGIN_VERSION', '3.2.3');
 
 require_once(WPSP_PLUGIN_DIR . 'sparkpost.class.php');
 


### PR DESCRIPTION
This was a customer reported issue.  See screenshot.

<img width="512" alt="logo" src="https://user-images.githubusercontent.com/1335605/91890215-2419b680-ec5d-11ea-823c-de0b878ca22c.png">

To verify this fix worked correctly:
1. We will need to deploy a new version v3.2.3 of the plugin
1. Then confirm all files in assets/ arrive in https://plugins.trac.wordpress.org/browser/sparkpost/assets