### PR TITLE
Require PHPMailer\Exception

### DIFF
--- a/mailer.http.class.php
+++ b/mailer.http.class.php
@@ -6,6 +6,7 @@ namespace WPSparkPost;
 if (!defined('ABSPATH')) exit();
 
 require_once ABSPATH . WPINC . '/PHPMailer/PHPMailer.php';
+require_once ABSPATH . WPINC . '/PHPMailer/Exception.php';
 require_once WPSP_PLUGIN_DIR . '/templates.class.php';
 
 class SparkPostHTTPMailer extends \PHPMailer\PHPMailer\PHPMailer


### PR DESCRIPTION
Fixes #162 

SparkPost plugin includes PHPMailer but don't include PHPMailer\Exception, which causes an error when sending email.

Error happens because WordPress Core will never include PHPMailer/Exception, because SparkPost has already included it.
WordPress won't include PHPMailer/Exception, bacause of this code in wp-includes/pluggable.php:

```
// (Re)create it, if it's gone missing.
if ( ! ( $phpmailer instanceof PHPMailer\PHPMailer\PHPMailer ) ) {
	require_once ABSPATH . WPINC . '/PHPMailer/PHPMailer.php';
	require_once ABSPATH . WPINC . '/PHPMailer/SMTP.php';
	require_once ABSPATH . WPINC . '/PHPMailer/Exception.php';
	$phpmailer = new PHPMailer\PHPMailer\PHPMailer( true );

	$phpmailer::$validator = static function ( $email ) {
		return (bool) is_email( $email );
	};
}
```