### PR TITLE
security(xss): escape template value

### DIFF
--- a/admin.widget.class.php
+++ b/admin.widget.class.php
@@ -398,7 +398,7 @@ class SparkPostAdmin
     {
         ?>
         <input type="text" id="template" name="sp_settings_basic[template]" class="regular-text"
-               value="<?php echo $this->settings['template']; ?>"/><br/>
+               value="<?php echo esc_attr($this->settings['template']); ?>"/><br/>
         <small>
             <ul>
                 <li>- Please see <a


### PR DESCRIPTION
security fix to fix one xss error.

If the database settings gets modified, to contain a a script, for the nested setting sp_settings_basic[template]

POC: 
run wp cli command to modify value and visit settings page with the template setting.
`wp option patch update sp_settings_basic template "value\"><script>alert('payload')</script>"`